### PR TITLE
Add cdefs for OpenBSD

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ install:
 	test -d ~/.drops || (cp -arp ../non-commercial ~/.drops || true)
 
 dropsd: dh.o drops.o peer.o message.o misc.o base64.o ssl.o main.o flavor-linux.o numbers.o missing.o config.o
-	$(LD) $^ -o dropsd $(LIBS)
+	$(LD) dh.o drops.o peer.o message.o misc.o base64.o ssl.o main.o flavor-linux.o numbers.o missing.o config.o -o dropsd $(LIBS)
 
 clean:
 	rm -rf *.o

--- a/src/drops.cc
+++ b/src/drops.cc
@@ -18,6 +18,7 @@
  * along with drops.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sys/cdefs.h>
 #define _POSIX_SOURCE
 #include <stdint.h>
 #include <string>


### PR DESCRIPTION
It seems that `__POSIX_SOURCE` overrides `__POSIX_VISIBLE` in a negative way so that `localtime_r` does not get defined correctly on OpenBSD:
```
eg++ -c -O2 -Wall -pedantic -std=c++11   -DHAVE_BN_GENCB_NEW=0 -DHAVE_LIBRESSL drops.cc
drops.cc: In member function 'int drops::log::logit(const string&, const string&, time_t)':
drops.cc:85:21: error: 'localtime_r' was not declared in this scope
  localtime_r(&t, &tm);
                     ^
```

Including `<sys/cdefs.h>` works around the problem but I'm not sure it is the correct fix.